### PR TITLE
feature: added dbt-date macros support used for dbt-expectations

### DIFF
--- a/macros/dbt_date_macros/convert_timezone.sql
+++ b/macros/dbt_date_macros/convert_timezone.sql
@@ -1,0 +1,9 @@
+{%- macro teradata__convert_timezone(column, target_tz=None, source_tz=None) -%}
+    {%- if source_tz == 'UTC' -%}
+      {% set source_tz = 'GMT' %}
+    {%- endif -%}
+    CAST(
+        (CAST({{ column }} AS {{ dbt.type_timestamp() }}) AT TIME ZONE '{{ source_tz or "GMT" }}') 
+        AT TIME ZONE '{{ target_tz }}'
+    AS {{ dbt.type_timestamp() }})
+{%- endmacro -%}

--- a/macros/dbt_date_macros/get_base_dates.sql
+++ b/macros/dbt_date_macros/get_base_dates.sql
@@ -1,0 +1,42 @@
+{% macro teradata__get_base_dates(start_date, end_date, n_dateparts, datepart) %}
+
+    {%- if start_date and end_date -%}
+        {%- set start_date = (
+            "cast('" ~ start_date ~ "' as " ~ dbt.type_timestamp() ~ ")"
+        ) -%}
+        {%- set end_date = (
+            "cast('" ~ end_date ~ "' as " ~ dbt.type_timestamp() ~ ")"
+        ) -%}
+
+    {%- elif n_dateparts and datepart -%}
+
+        {%- set start_date -%} 
+            cast(
+            {{ dbt.dateadd(
+            datepart, -1 * n_dateparts, dbt_date.today())}} as date)
+        {%- endset -%}
+        {%- set end_date = dbt_date.tomorrow() -%}
+    {%- endif -%}
+
+    {% set intervals = dbt_utils.get_intervals_between(start_date, end_date, datepart) %}
+
+    with
+        date_spine as (
+
+            SELECT date_val as date_{{datepart}}
+
+            FROM (
+
+                SELECT {{ dbt.dateadd(datepart, 'row_number() over (order by generated_number) - 1', start_date) }} as date_val
+
+                FROM ({{ dbt_utils.generate_series(intervals) }}) as gs
+
+            ) as sub
+
+            WHERE date_val <= {{ end_date }}
+
+        )
+    select
+        cast(d.date_{{ datepart }} as {{ dbt.type_timestamp() }}) as date_{{ datepart }}
+    from date_spine d
+{% endmacro %}


### PR DESCRIPTION
### Description

This PR adds dbt_date macros for extending support to dbt_expectations package.
This is a workaround for not adding support to dbt_date directly instead adding only the macros which are directly impact teradata's support in dbt-expectations package


### Checklist
 - [ ] I have run this code in development and it appears to resolve the stated issue
 - [ ] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` with information about my change
